### PR TITLE
Update .editorconfig and project dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,7 @@ dotnet_style_operator_placement_when_wrapping = beginning_of_line
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = false:silent
 dotnet_style_prefer_conditional_expression_over_return = false:silent
@@ -131,6 +132,7 @@ csharp_prefer_braces = true:silent
 csharp_prefer_simple_using_statement = true:suggestion
 csharp_style_namespace_declarations = file_scoped:suggestion
 csharp_style_prefer_method_group_conversion = true:silent
+csharp_prefer_system_threading_lock = true:suggestion
 
 # Expression-level preferences
 csharp_prefer_simple_default_expression = true:suggestion
@@ -243,23 +245,23 @@ dotnet_naming_rule.async_method_should_be_ends_with_async.style = ends_with_asyn
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
+dotnet_naming_symbols.interface.required_modifiers =
 
 dotnet_naming_symbols.method.applicable_kinds = method
 dotnet_naming_symbols.method.applicable_accessibilities = public
-dotnet_naming_symbols.method.required_modifiers = 
+dotnet_naming_symbols.method.required_modifiers =
 
 dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
 dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private, private_protected
-dotnet_naming_symbols.private_or_internal_field.required_modifiers = 
+dotnet_naming_symbols.private_or_internal_field.required_modifiers =
 
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
+dotnet_naming_symbols.types.required_modifiers =
 
 dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
+dotnet_naming_symbols.non_field_members.required_modifiers =
 
 dotnet_naming_symbols.async_method.applicable_kinds = method
 dotnet_naming_symbols.async_method.applicable_accessibilities = *
@@ -267,24 +269,24 @@ dotnet_naming_symbols.async_method.required_modifiers = async
 
 # Naming styles
 
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-dotnet_naming_style.camel_case.required_prefix = 
-dotnet_naming_style.camel_case.required_suffix = 
-dotnet_naming_style.camel_case.word_separator = 
+dotnet_naming_style.camel_case.required_prefix =
+dotnet_naming_style.camel_case.required_suffix =
+dotnet_naming_style.camel_case.word_separator =
 dotnet_naming_style.camel_case.capitalization = camel_case
 
-dotnet_naming_style.ends_with_async.required_prefix = 
+dotnet_naming_style.ends_with_async.required_prefix =
 dotnet_naming_style.ends_with_async.required_suffix = Async
-dotnet_naming_style.ends_with_async.word_separator = 
+dotnet_naming_style.ends_with_async.word_separator =
 dotnet_naming_style.ends_with_async.capitalization = pascal_case
 
 # IDE0058: Expression value is never used
@@ -295,3 +297,6 @@ dotnet_diagnostic.IDE0010.severity = none
 
 # IDE0072: Add missing cases
 dotnet_diagnostic.IDE0072.severity = none
+
+# IDE0305: Simplify collection initialization
+dotnet_diagnostic.IDE0305.severity = none

--- a/IdentitySample/IdentitySample.Authentication/IdentitySample.Authentication.csproj
+++ b/IdentitySample/IdentitySample.Authentication/IdentitySample.Authentication.csproj
@@ -6,8 +6,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.6" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/IdentitySample/IdentitySample.DataAccessLayer/IdentitySample.DataAccessLayer.csproj
+++ b/IdentitySample/IdentitySample.DataAccessLayer/IdentitySample.DataAccessLayer.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/IdentitySample/IdentitySample.StorageProviders/IdentitySample.StorageProviders.csproj
+++ b/IdentitySample/IdentitySample.StorageProviders/IdentitySample.StorageProviders.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Storage.Blobs" Version="12.24.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
 		<PackageReference Include="MimeMapping" Version="3.1.0" />
 	</ItemGroup>
 </Project>

--- a/IdentitySample/IdentitySample/IdentitySample.csproj
+++ b/IdentitySample/IdentitySample/IdentitySample.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Hi @marcominerva this pull request includes updates to NuGet package dependencies across several projects to their latest patch versions and introduces new .editorconfig rules to improve code style consistency. The most important changes are grouped below:

**Dependency Updates:**

* Updated `Microsoft.AspNetCore.Authorization` and `Microsoft.AspNetCore.Identity.EntityFrameworkCore` from version 9.0.6 to 9.0.8 in `IdentitySample.Authentication.csproj`
* Updated `Microsoft.EntityFrameworkCore.SqlServer` from version 9.0.6 to 9.0.8 in both `IdentitySample.DataAccessLayer.csproj` and `IdentitySample/IdentitySample.csproj` [[1]](diffhunk://#diff-2c9bb738cf479c94537b415ebcc45247eb817507cbab49e170b31153a447eb72L9-R9) [[2]](diffhunk://#diff-6f9d778f8c5ab0b03cf5e3366d4b858b4bb666cb59a7375519c718fe809c5b64L11-R13)
* Updated `Azure.Storage.Blobs` from 12.24.1 to 12.25.0 and `Microsoft.Extensions.Hosting` from 9.0.6 to 9.0.8 in `IdentitySample.StorageProviders.csproj`
* Updated `Swashbuckle.AspNetCore` from 9.0.1 to 9.0.4 in `IdentitySample/IdentitySample.csproj`

**Code Style and Analyzer Configuration:**

* Added `.editorconfig` rules for preferring collection expressions and using `System.Threading.Monitor`-based locks, and disabled the IDE0305 analyzer for collection initialization simplification [[1]](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR25) [[2]](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR135) [[3]](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR300-R302)